### PR TITLE
[MSS-1904] Add line number to xml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,12 @@ class CypressCircleCIReporter extends Mocha.reporters.Base {
 
       const failureMessage = err.stack || message;
 
+      let testcaseAttributes = {
+        ...this.getTestcaseAttributes(test),
+        line_number: JSON.parse(test.inspect()).invocationDetails.line,
+      };
       root
-        .ele('testcase', this.getTestcaseAttributes(test))
+        .ele('testcase', testcaseAttributes)
         .ele('failure', {
           message: removeInvalidCharacters(message) || '',
           type: err.name || '',


### PR DESCRIPTION
## Description
We are able to fetch the line number off of the invocationDetails when inspecting the test.
However, I am looking for another way to find the invocation details.

This change will be ready when:
- [ ] We have confirmed with CircleCI that there is not a better solution
- [ ] We have tests up and running for this (presently they should break).