### PR TITLE
Include skipped tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ const {
   EVENT_RUN_END,
   EVENT_TEST_FAIL,
   EVENT_TEST_PASS,
+  EVENT_TEST_PENDING,
   EVENT_SUITE_BEGIN,
 } = Runner.constants;
 
@@ -87,6 +88,10 @@ class CypressCircleCIReporter extends Mocha.reporters.Base {
           type: err.name || '',
         })
         .ele({ $: removeInvalidCharacters(failureMessage) });
+    });
+
+    runner.on(EVENT_TEST_PENDING, (test: Test) => {
+      root.ele('testcase', this.getTestcaseAttributes(test));
     });
 
     runner.on(EVENT_RUN_END, () => {

--- a/test/reporter.test.ts
+++ b/test/reporter.test.ts
@@ -16,7 +16,10 @@ function formatDate(date: Date) {
 
 describe('reporter', () => {
   beforeEach(() => {
-    fs.rmdirSync(`./test_results/cypress`, { recursive: true });
+    const directory = `./test_results/cypress`;
+    if (fs.existsSync(directory)) {
+      fs.rmdirSync(directory, { recursive: true });
+    }
   });
 
   it('creates proper xml for test run', () => {
@@ -82,6 +85,7 @@ describe('reporter', () => {
     const test1DurationFormatted = formatDuration(test1.duration);
     const test2DurationFormatted = formatDuration(test2.duration);
     const test3DurationFormatted = formatDuration(test3.duration);
+    const test4DurationFormatted = formatDuration(test4.duration);
     const test5DurationFormatted = formatDuration(test5.duration);
 
     const files = fs.readdirSync('./test_results/cypress');
@@ -103,6 +107,7 @@ describe('reporter', () => {
             <![CDATA[some test stack]]>
           </failure>
         </testcase>
+        <testcase name="${test4.title}" file="${testFile}" time="${test4DurationFormatted}" classname="root"/>
         <testcase name="${test5.title}" file="${testFile}" time="${test5DurationFormatted}" classname="root.nested"/>
       </testsuite>`;
 


### PR DESCRIPTION
Skipped tests are currently not being reported by `cypress-circleci-reporter`. This causes `circleci tests split` to complain about missing timings.

This PR adds support for skipped tests, so they will also be included in the xml reports.